### PR TITLE
feat: add copycat workflow

### DIFF
--- a/.github/workflows/copycat.yml
+++ b/.github/workflows/copycat.yml
@@ -1,0 +1,22 @@
+name: Copy-to-live
+on:
+  push:
+    branches:
+      - live
+
+jobs:
+  copy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Copycat
+      uses: andstor/copycat-action@v3
+      with:
+        personal_token: ${{ secrets.COPYCAT_TOKEN }}
+        src_path: /.
+        dst_path: /.
+        dst_owner: dhbw-ka-pm
+        dst_repo_name: mentalmodels-for-teams-live
+        dst_branch: gh-pages
+        src_branch: live
+        clean: true
+        exclude: */.github/workflows/*


### PR DESCRIPTION
This introduces the copycat workflow: https://github.com/marketplace/actions/copycat-action

This will allow contributors to push content (intentionally the gh-pages branch) to the 'live' branch in order to automatically copy all content over to the mentalmodels-for-teams-live repository, which will (as the name states) act as our "live host" for our github pages. The gh-pages hosted on this repository will therefore become a test environment.

fixes #72 